### PR TITLE
Remove Reference to deprecated PodSecurityPolicy

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -45,7 +45,7 @@ Which resources are namespaced? and which are cluster scoped?
 
 For cluster scoped: `k api-resources --namespaced=false`
 
-What is the shortname for `PodSecurityPolicy`?
+What is the shortname for `ServiceAccount`?
 
 5. Explaining Resources
 


### PR DESCRIPTION
PodSecurityPolicy was referenced arbitrarily, however it was deprecated and isn't a good choice in general.  Replacing with `ServiceAccount` which is expected to be much more stable.

fixes: #3 
Signed-off-by: Ken Sipe <kensipe@gmail.com>